### PR TITLE
[docs] jwt, oauth2 yml & gitignore에 yml 두개 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 
+application-jwt.yml
+application-oauth2.yml
+
 ### STS ###
 .apt_generated
 .classpath

--- a/src/main/resources/application-jwt.yml
+++ b/src/main/resources/application-jwt.yml
@@ -1,0 +1,3 @@
+spring:
+  jwt:
+    secret: "${JWT_SECRET}"

--- a/src/main/resources/application-oauth2.yml
+++ b/src/main/resources/application-oauth2.yml
@@ -1,0 +1,40 @@
+spring:
+  # oauth2 관련 설정
+  security:
+    oauth2:
+      client:
+        registration:
+          naver:
+            client-name: naver
+            client-id: "${NAVER_CLIENT_ID}"
+            client-secret: "${NAVER_CLIENT_SECRET}"
+            redirect-uri: http://localhost:8080/login/oauth2/code/naver
+            authorization-grant-type: authorization_code
+            scope: name,email
+          kakao:
+            client-name: Kakao
+            client-id: "${KAKAO_CLIENT_ID}"
+            client-authentication-method: "${KAKAO_AUTHENTICATION_METHOD}"
+            redirect-uri: "http://localhost:8080/login/oauth2/code/kakao"
+            authorization-grant-type: authorization_code
+            scope: profile_nickname, account_email #동의 항목
+          google:
+            client-name: google
+            client-id: "${GOOGLE_CLIENT_ID}"
+            client-secret: "${GOOGLE_CLIENT_SECRET}"
+            redirect-uri: http://localhost:8080/login/oauth2/code/google
+            authorization-grant-type: authorization_code
+            scope: profile,email
+        provider:
+          naver:
+            authorization-uri: https://nid.naver.com/oauth2.0/authorize
+            token-uri: https://nid.naver.com/oauth2.0/token
+            user-info-uri: https://openapi.naver.com/v1/nid/me
+            user-name-attribute: response
+          kakao:
+            authorization-uri: https://kauth.kakao.com/oauth/authorize
+            token-uri: https://kauth.kakao.com/oauth/token
+            user-info-uri: https://kapi.kakao.com/v2/user/me
+            user-name-attribute: id
+
+


### PR DESCRIPTION
appication.yml 에 jwt 와 oauth2 설정을 한꺼번에 적었었고
클라이언트 id, secret 키를 그대로 적어서 보안상 문제로 
푸쉬가 되지 않았음. 

그래서 appication-jwt.yml  
appication-oauth2.yml 파일을 따로 생성했고 

환경변수로 설정해서 클라이언트 id, secret 키를 숨겼습니다. 

아직 보안 세팅이 덜되었지만, 테스트 푸쉬 보낸것입니다.